### PR TITLE
Update demux_run_dag.py

### DIFF
--- a/demux_run_dag.py
+++ b/demux_run_dag.py
@@ -168,7 +168,7 @@ with DAG(
                 if not os.path.exists(project_dir):
                     project_dir = "/igo/staging/FASTQ/" + sequencer_and_run + "/" + project
                 output_dir = "/igo/staging/stats/" + sequencer_and_run + "/" + project
-                cmd = "python3 /igo/work/nabors/tools/wgs_python/wgs_stats_bwa_mem2.py --project-dir {} --output-dir {}".format(project_dir, output_dir)
+                cmd = "python3 /igo/work/nabors/tools/wgs_python/bwa_mem2_only.py --project-dir {} --output-dir {}".format(project_dir, output_dir)
                 print(cmd)
                 cmd_list.append(cmd)
         return cmd_list


### PR DESCRIPTION
changed bwa_mem2 portion to point to a new script called bwa_mem2_only.py.  this script only allows for the generation of the bwa-mem2 bams.  No Picard jobs will run after this.  this will free up the queue and allow other jobs to run.